### PR TITLE
Fix typo `截至` → `截止`

### DIFF
--- a/archive/mol4/Mol4 比赛系统.html
+++ b/archive/mol4/Mol4 比赛系统.html
@@ -369,7 +369,7 @@
           <div class="mt-3">
             <h3 class="text-xl lg:text-2xl font-heading-light text-black">提交入口</h3>
             <p>请将每道题的答案分别写在一张A4纸上，拍照或扫描答案，提交至邮箱mirturlol@163.com</p>
-            <p>截至时间：8/31 23:59 (UTC+8)</p>
+            <p>截止时间：8/31 23:59 (UTC+8)</p>
           </div>
           <div class="mt-3">
             <h3 class="text-xl lg:text-2xl font-heading-light text-black">赛后问卷</h3>


### PR DESCRIPTION
“截至”大致相当于“截止于”，此处“截至日期”应该是“截止日期”。

- [截至日期-语料库搜索](http://ccl.pku.edu.cn:8080/ccl_corpus/search?q=%E6%88%AA%E8%87%B3%E6%97%A5%E6%9C%9F&dir=xiandai)：共在 348 个文档中出现
- [截止日期-语料库搜索](http://ccl.pku.edu.cn:8080/ccl_corpus/search?q=%E6%88%AA%E6%AD%A2%E6%97%A5%E6%9C%9F&dir=xiandai)：共在 7106 个文档中出现

[截至-语料库搜索](http://ccl.pku.edu.cn:8080/ccl_corpus/search?q=%E6%88%AA%E8%87%B3&dir=xiandai)：

> 他所教的经济思潮是**截至**一八九0年为止的
> 论我的作品，**截至**一九二六年冬止写《最后的幸福》后
> 而**截至**今日，我恰恰发表过十本作品
> 六万救火员中，**截至**上月底，殉职的已逾百名。

[截止-语料库搜索](http://ccl.pku.edu.cn:8080/ccl_corpus/search?q=%E6%88%AA%E6%AD%A2&dir=xiandai)：

> 丁某命即**截止**，因为报瓦曰
> 当下**截止**招募，带领七百人回濠
> 利息只能算到今日**截止**，以后无论迟延多少日子
> 就这样小生命被**截止**了。